### PR TITLE
Add travis-ci.org support for public repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - make package
+
+deploy:
+  provider: releases
+  api_key:
+    secure: ikSQ8t+CSrqOokNpbnSL77EOG09473MgSKTH6bDbkxipEFgxgY0fsZzuCwypzvZOzwj8rcKBRWRvNwIs+g4+aeRMV+xAa0oGprr7Cg7PLgN3w6JuXU949IG9lu0+Futa0UwO14HVTOgLJ1mFWDqQGtkFSjeDygDWS0LJjqqrMCP3GHo0VUVQvcOKHmVATt2jU5iuKRxsR6qkrZVvQtnrWD1PW4DggKm28mEapuL6M4koUJC/VUJn77DRkawsnZPx/QPeZD3z5vqUF+LkdKO4YWzzvxcllpEaG2i9cAjIobovsJh9ms6i42Kn2RbAM36dO/VAQD6/fDxzyxFTQBueDEchaz/q73r/iXPOKiSS2QiIJivXlcYIN+hYLCmEI7S1d/xy4+EH8DdeZ9sAQv4PMx822st7ZFv5AWZ+9oER4l0fd9dwK5AQnPTtkqBH3XUx4QwCK/4s4SJtBrxqmeOU3dPQJjxB0e+eDEwtksWTngv3CfOl84jMblW0SMMxUNEdmVBXTNMYWpdU4QMvI9vYItQe/j7bfl7pVmCwY2AW3VovQicBZzk8cnxLMrk4YtX8GI3/cNBe26voYsncuTEzrKVPqqp6xEMD3xX9Obov7+5aS+0Dqk8rB7O1tRgGICAYSE3Y1clUWyJXyWmXbMztXFogKwjBvt0nO76N1rKA0Vk=
+  file: build/f5-lbaas_1.0.12.tgz
+  on:
+    repo: F5Networks/f5-openstack-lbaasv1
+    tags: true
+
+notifications:
+  slack:
+    rooms:
+      - f5openstackdev:$SLACK_PROJECT_TOKEN
+    on_success: change
+    on_failure: always

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ deploy:
   provider: releases
   api_key:
     secure: ikSQ8t+CSrqOokNpbnSL77EOG09473MgSKTH6bDbkxipEFgxgY0fsZzuCwypzvZOzwj8rcKBRWRvNwIs+g4+aeRMV+xAa0oGprr7Cg7PLgN3w6JuXU949IG9lu0+Futa0UwO14HVTOgLJ1mFWDqQGtkFSjeDygDWS0LJjqqrMCP3GHo0VUVQvcOKHmVATt2jU5iuKRxsR6qkrZVvQtnrWD1PW4DggKm28mEapuL6M4koUJC/VUJn77DRkawsnZPx/QPeZD3z5vqUF+LkdKO4YWzzvxcllpEaG2i9cAjIobovsJh9ms6i42Kn2RbAM36dO/VAQD6/fDxzyxFTQBueDEchaz/q73r/iXPOKiSS2QiIJivXlcYIN+hYLCmEI7S1d/xy4+EH8DdeZ9sAQv4PMx822st7ZFv5AWZ+9oER4l0fd9dwK5AQnPTtkqBH3XUx4QwCK/4s4SJtBrxqmeOU3dPQJjxB0e+eDEwtksWTngv3CfOl84jMblW0SMMxUNEdmVBXTNMYWpdU4QMvI9vYItQe/j7bfl7pVmCwY2AW3VovQicBZzk8cnxLMrk4YtX8GI3/cNBe26voYsncuTEzrKVPqqp6xEMD3xX9Obov7+5aS+0Dqk8rB7O1tRgGICAYSE3Y1clUWyJXyWmXbMztXFogKwjBvt0nO76N1rKA0Vk=
-  file: build/f5-lbaas_1.0.12.tgz
+  file: build/f5-lbaas_$TRAVIS_TAG.tgz
+  skip_cleanup: true
   on:
     repo: F5Networks/f5-openstack-lbaasv1
     tags: true
@@ -18,6 +19,7 @@ deploy:
 notifications:
   slack:
     rooms:
-      - f5openstackdev:$SLACK_PROJECT_TOKEN
+      - f5openstackdev:$SLACK_TOKEN#f5-openstack-lbaasv1
+      - f5openstackdev:$SLACK_TOKEN#build_status
     on_success: change
     on_failure: always

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker_all: docker_debs docker_el7_rpms docker_el6_rpms
 
 package: docker_all
 	sudo chmod 777 build
-	tar czvf build/f5-lbaas_$(VERSION).tgz README.rst SUPPORT.md build/deb_dist/*.deb build/el7/*.noarch.el7.rpm build/el6/*.noarch.el6.rpm
+	tar czvf build/f5-lbaas_$(VERSION)$(RELEASE).tgz README.rst SUPPORT.md build/deb_dist/*.deb build/el7/*.noarch.el7.rpm build/el6/*.noarch.el6.rpm
 
 docker_debs:
 	(docker build -t deb-pkg-builder ./Docker/debian)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ rpms: build/f5-oslbaasv1-driver-$(VERSION).noarch.rpm \
 docker_all: docker_debs docker_el7_rpms docker_el6_rpms
 
 package: docker_all
+	sudo chmod 777 build
 	tar czvf build/f5-lbaas_$(VERSION).tgz README.rst SUPPORT.md build/deb_dist/*.deb build/el7/*.noarch.el7.rpm build/el6/*.noarch.el6.rpm
 
 docker_debs:

--- a/README.rst
+++ b/README.rst
@@ -179,5 +179,5 @@ Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>
 to Openstack_CLA@f5.com prior to their
 | code submission being included in this project.
 
-.. |Build Status| image:: https://travis-ci.com/F5Networks/openstack-f5-lbaasv1.svg?token=9DzDpZ48B74dRXvdFxM2&branch=master
-   :target: https://travis-ci.com/F5Networks/openstack-f5-lbaasv1
+.. |Build Status| image:: https://travis-ci.org/F5Networks/openstack-f5-lbaasv1.svg?token=9DzDpZ48B74dRXvdFxM2&branch=1.0
+   :target: https://travis-ci.org/F5Networks/openstack-f5-lbaasv1


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
WIP #2 

#### What's this change do?
Adds travis-ci support and does the `make package` command to build a full release.

#### Where should the reviewer start?
Look at the `.travis.yml` file and the change to the `Makefile`.  I had to change permissions on the build directory in because the containers are building as `root` but the job is running as the `travis` user so there was not enough permissions to create the `.tgz` file in the `build` directory.

#### Any background context?
I have the GitHub integration stuff int here for the release but can't test it because it is in my private repo and will need to do that in the base repo.