### PR TITLE
Release Docs for 1.0.12

### DIFF
--- a/doc/release_deb.md
+++ b/doc/release_deb.md
@@ -21,7 +21,7 @@ service_provider=LOADBALANCER:F5:f5.oslbaasv1driver.drivers.plugin_driver.F5Plug
 ```
 # service neutron-server restart
 ```
-4. Enable LBaaS on the Controller Node
+4. Enable LBaaS on the Controller Node (**NOTE:** This step is not necessary from Kilo forward.)
 ```
 # vi 'local_settings'
 OPENSTACK_NEUTRON_NETWORK = { 'enable_lb': True, ...}"

--- a/doc/release_deb.md
+++ b/doc/release_deb.md
@@ -1,0 +1,44 @@
+# f5-openstack-lbaasv1 v1.0.12
+
+## Ubuntu Configuration instructions
+
+### Before you begin
+In order to use the Neutron command set, you need source a user file that has admin permissions. (for example, `source keystonerc_admin`).
+
+### Configure the F5 LBaaSv1 Plugin
+1. Configure the agent (/etc/neutron/f5-bigip-lbaas-agent.ini).
+2. Configure the Neutron service to use the F5 plugin.
+**NOTE:** In the service providers section, the f5.os.lbaasv1driver entry will most likely be present, but commented out. *Uncomment this line and comment out the HA proxy line to identify the F5 plugin as the lbaas service provider.* Add ':default' to the end of the line as shown below to set it as the default LBaaS service.
+```
+# vi /etc/neutron/neutron_lbaas.conf
+[DEFAULT]
+loadbalancer_plugin = neutron.services.loadbalancer.plugin.LoadBalancerPlugin
+...
+[service providers]
+service_provider=LOADBALANCER:F5:f5.oslbaasv1driver.drivers.plugin_driver.F5PluginDriver:default
+```   
+3. Restart the neutron service:
+```
+# service neutron-server restart
+```
+4. Enable LBaaS on the Controller Node
+```
+# vi 'local_settings'
+OPENSTACK_NEUTRON_NETWORK = { 'enable_lb': True, ...}"
+```
+5. Restart the http service:
+```
+# service apache2 restart
+```
+6. Start the agent: 
+```
+# service f5-oslbaasv1-agent start
+```
+
+To check the status of the agent:
+```
+# neutron agent-list
+
+# neutron agent-show f5-oslbaasv1-agent
+
+```

--- a/doc/release_readme.md
+++ b/doc/release_readme.md
@@ -1,0 +1,86 @@
+# f5-openstack-lbaasv1
+
+## Release Version
+
+**1.10.12**
+
+## Compatibility
+
+Product | Version(s) 
+---|---
+OpenStack LBaaSv1 | Havana - Kilo
+BIG-IP | 11.5.x, 11.6.x, 12.0.x
+Red Hat Enterprise Linux / CentOS | 6, 7
+Ubuntu | 12.04, 14.04
+
+## Package Contents
+- build
+    - deb_dist : Ubuntu installation files
+    - el6 : Red Hat / CentOS 6 installation files 
+    - el7 : Red Hat / CentOS 7 installation files
+    - Release Readme (this document)
+    - Support.md
+
+
+## Installation
+
+### Prerequisites:
+- OpenStack Neutron network deployment
+- Licensed BIG-IP (hardware or virtual edition)
+
+### Red Hat / CentOS
+
+1. Install the F5 BIG-IP common libraries.
+```
+# rpm -ivh f5-bigip-common_1.0.12.noarch.el7.rpm
+``` 
+2. Install the plugin driver.
+```
+# rpm -i f5-lbaas-driver-1.0.12.noarch.el7.rpm 
+```
+3. Install the agent.
+```
+# rpm -i f5-bigip-lbaas-agent-1.0.12.noarch.el7.rpm
+```
+
+### Ubuntu
+1. Install the F5 BIG-IP common libraries.
+```
+dpkg -i f5-bigip-common_1.0.12_all.deb
+```
+2. Install the plugin driver.
+```
+# dpkg -i f5-lbaas-driver_1.0.12_all.deb
+```
+3. Install the plugin agent.
+```
+# dpkg -i f5-bigip-lbaas-agent_1.0.12_all.deb
+```
+
+## Contact
+f5_openstack_lbaasv1@f5.com
+
+## Copyright
+Copyright 2016 F5 Networks Inc.
+
+## Support
+See Support.md.
+
+## License
+
+Apache V2.0
+------------
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+implied.
+See the [License](http://www.apache.org/licenses/LICENSE-2.0) for the 
+specific language governing permissions and limitations under the 
+License.

--- a/doc/release_rpm.md
+++ b/doc/release_rpm.md
@@ -1,0 +1,43 @@
+# f5-openstack-lbaasv1 v1.0.12
+
+## Red Hat / CentOS Configuration instructions
+
+### Before you begin
+In order to use the Neutron command set, you need source a user file that has admin permissions. (for example, `source keystonerc_admin`).
+
+### Configure the F5 LBaaSv1 Plugin
+1. Configure the agent (/etc/neutron/f5-oslbaasv1-agent.ini).
+2. Configure the Neutron service to use the F5 plugin.
+3. Set the LBaaS service provider.
+**NOTE:** In the service providers section, the f5.os.lbaasv1driver entry will most likely be present, but commented out. *Uncomment this line and comment out the HA proxy line to identify the F5 plugin as the lbaas service provider.* Add ':default' to the end of the line as shown below to set it as the default LBaaS service.
+```
+# vi /etc/neutron/neutron_lbaas.conf
+...
+[service providers]
+service_provider=LOADBALANCER:F5:f5.oslbaasv1driver.drivers.plugin_driver.F5PluginDriver:default
+```   
+4. Restart the neutron-server service:
+```
+# systemctl restart neutron-server
+```
+5. Enable LBaaS on the Controller Node
+```
+# vi 'local_settings'
+OPENSTACK_NEUTRON_NETWORK = { 'enable_lb': True, ...}"
+```
+6. Restart the http service.
+```
+# service httpd restart
+```
+7. Start the agent. 
+```
+# service f5-oslbaasv1-agent start
+```
+
+To check the status of the agent:
+```
+# neutron agent-list
+
+# neutron agent-show f5-oslbaasv1-agent
+
+```

--- a/doc/release_rpm.md
+++ b/doc/release_rpm.md
@@ -8,7 +8,6 @@ In order to use the Neutron command set, you need source a user file that has ad
 ### Configure the F5 LBaaSv1 Plugin
 1. Configure the agent (/etc/neutron/f5-oslbaasv1-agent.ini).
 2. Configure the Neutron service to use the F5 plugin.
-3. Set the LBaaS service provider.
 **NOTE:** In the service providers section, the f5.os.lbaasv1driver entry will most likely be present, but commented out. *Uncomment this line and comment out the HA proxy line to identify the F5 plugin as the lbaas service provider.* Add ':default' to the end of the line as shown below to set it as the default LBaaS service.
 ```
 # vi /etc/neutron/neutron_lbaas.conf
@@ -16,20 +15,20 @@ In order to use the Neutron command set, you need source a user file that has ad
 [service providers]
 service_provider=LOADBALANCER:F5:f5.oslbaasv1driver.drivers.plugin_driver.F5PluginDriver:default
 ```   
-4. Restart the neutron-server service:
+3. Restart the neutron-server service:
 ```
 # systemctl restart neutron-server
 ```
-5. Enable LBaaS on the Controller Node
+4. Enable LBaaS on the Controller Node (**NOTE:** This step is not necessary from Kilo forward.)
 ```
 # vi 'local_settings'
 OPENSTACK_NEUTRON_NETWORK = { 'enable_lb': True, ...}"
 ```
-6. Restart the http service.
+5. Restart the http service.
 ```
 # service httpd restart
 ```
-7. Start the agent. 
+6. Start the agent. 
 ```
 # service f5-oslbaasv1-agent start
 ```


### PR DESCRIPTION
## What's this change do?

Adds the top-level readme for the 1.0.12 release.
Adds the OS-specific readmes for the 1.0.12 release.

## Where should the reviewer start?
I think this should be good now - it's just the release-specific docs.

## Any background context?
nope.