### PR TITLE
Update version strings for 2.0.1 final release.

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,1 +1,1 @@
-rc1
+final

--- a/doc/f5-oslbaasv1-readme.md
+++ b/doc/f5-oslbaasv1-readme.md
@@ -207,12 +207,12 @@ host(s) and install it.
 Debian / Ubuntu example:
 
 <span class="command_text">dpkg -i
-f5-oslbaasv1-driver\_2.0.1\_all.deb</span>
+f5-oslbaasv1-driver\_2.0.1-final\_all.deb</span>
 
 Rad Hat example:
 
 <span class="command_text">rpm -ivh
-f5-oslbaasv1-driver-2.0.1.noarch.el7.rpm</span>
+f5-oslbaasv1-driver-2.0.1-final.noarch.el7.rpm</span>
 
 Changes to the neutron server configuration file will then need to be
 made to enable LBaaSv1 services and reference the f5 LBaaSv1 service
@@ -279,16 +279,16 @@ be the Neutron controller, but does not have to be.
 Debian / Ubuntu example:
 
 <span class="command_text">dpkg -i
-f5-bigip-common\_2.0.1\_all.deb</span> <span
+f5-bigip-common\_2.0.1-final\_all.deb</span> <span
 class="command_text">dpkg -i
-f5-oslbaasv1-agent\_2.0.1\_all.deb</span>
+f5-oslbaasv1-agent\_2.0.1-final\_all.deb</span>
 
 Rad Hat example:
 
 <span class="command_text">rpm -ivh
-f5-bigip-common-2.0.1.noarch.el7.rpm</span> <span
+f5-bigip-common-2.0.1-final.noarch.el7.rpm</span> <span
 class="command_text">rpm -ivh
-f5-oslbaasv1-agent-2.0.1.noarch.el7.rpm</span>
+f5-oslbaasv1-agent-2.0.1-final.noarch.el7.rpm</span>
 
 The installation will start a service called <span
 class="command_text">f5-oslbaasv1-agent</span>. Stop this service and

--- a/doc/release_deb.md
+++ b/doc/release_deb.md
@@ -1,4 +1,4 @@
-# f5-openstack-lbaasv1 v1.0.12
+# f5-openstack-lbaasv1 v2.0.1
 
 ## Ubuntu Configuration instructions
 

--- a/doc/release_readme.md
+++ b/doc/release_readme.md
@@ -2,13 +2,13 @@
 
 ## Release Version
 
-**1.0.12**
+**2.0.1**
 
 ## Compatibility
 
 Product | Version(s) 
 ---|---
-OpenStack LBaaSv1 | Havana - Kilo
+OpenStack LBaaSv1 | Liberty
 BIG-IP | 11.5.x, 11.6.x, 12.0.x
 Red Hat Enterprise Linux / CentOS | 6, 7
 Ubuntu | 12.04, 14.04
@@ -32,29 +32,29 @@ Ubuntu | 12.04, 14.04
 
 1. Install the F5 BIG-IP common libraries.
 ```
-# rpm -ivh f5-bigip-common_1.0.12.noarch.el7.rpm
+# rpm -ivh f5-bigip-common_2.0.1-final.noarch.el7.rpm
 ``` 
 2. Install the plugin driver.
 ```
-# rpm -i f5-lbaas-driver-1.0.12.noarch.el7.rpm 
+# rpm -i f5-lbaas-driver-2.0.1-final.noarch.el7.rpm 
 ```
 3. Install the agent.
 ```
-# rpm -i f5-bigip-lbaas-agent-1.0.12.noarch.el7.rpm
+# rpm -i f5-bigip-lbaas-agent-2.0.1-final.noarch.el7.rpm
 ```
 
 ### Ubuntu
 1. Install the F5 BIG-IP common libraries.
 ```
-# dpkg -i f5-bigip-common_1.0.12_all.deb
+# dpkg -i f5-bigip-common_2.0.1-final_all.deb
 ```
 2. Install the plugin driver.
 ```
-# dpkg -i f5-lbaas-driver_1.0.12_all.deb
+# dpkg -i f5-lbaas-driver_2.0.1-final_all.deb
 ```
 3. Install the plugin agent.
 ```
-# dpkg -i f5-bigip-lbaas-agent_1.0.12_all.deb
+# dpkg -i f5-bigip-lbaas-agent_2.0.1-final_all.deb
 ```
 
 ## Contact

--- a/doc/release_rpm.md
+++ b/doc/release_rpm.md
@@ -1,4 +1,4 @@
-# f5-openstack-lbaasv1 v1.0.12
+# f5-openstack-lbaasv1 v2.0.1
 
 ## Red Hat / CentOS Configuration instructions
 


### PR DESCRIPTION
@swormke 

#### What issues does this address?
Documentation updates for 2.0.1.

#### What's this change do?
Migrate 1.0.12 to 2.0.1 in release readme files.

#### Where should the reviewer start?

#### Any background context?

Tests:
* Manual inspection of documents
* Installed *.deb on Ubuntu 12.0.4
* Installed *.rpm on CentOS 7
* Created a pool on CentOS 7 as a canary test
* Examined /var/log/neutron/f5-oslbaasv1.log for errors loading new agent
* Examined docs in /usr/share/doc/f5-oslbaasv1-agent/