### PR TITLE
Update README to point to Read The Docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,102 +1,106 @@
-f5-openstack-lbassv1
+f5-openstack-lbaasv1
 ====================
 
-.. image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv1.svg?branch=1.0
-    :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv1
+    .. image:: https://travis-ci.org/F5Networks/f5-openstack-lbaasv1.svg?branch=1.0
+        :target: https://travis-ci.org/F5Networks/f5-openstack-lbaasv1
 
 Introduction
 ------------
 
 This repo houses the code for the F5 OpenStack LBaaSv1 plugin. Please
-see the
-`documentation <http://f5networks.github.io/f5-openstack-docs>`__ for
+see the `documentation <http://f5-openstack-lbaasv1.readthedocs.org/en/latest/>`__ for
 more information.
 
 Installation & Configuration
 ----------------------------
 
-See the
-`documentation <http://f5networks.github.io/f5-openstack-docs>`__.
+See the `documentation <http://f5-openstack-lbaasv1.readthedocs.org/en/latest/>`__.
 
 Filing Issues
 -------------
 
-| If you find an issue we would love to hear about it. Please let us
-know by
-| filing an issue in this repository and tell us as much as you can
-about what
-| you found and how you found it.
+If you find an issue we would love to hear about it. Please let us
+know by filing an issue in this repository and tell us as much as you can
+about what you found and how you found it.
 
 Contributing
 ------------
 
-See `Contributing <CONTRIBUTING.md>`__
+See `Contributing <CONTRIBUTING.md>`__.
 
 Build
 -----
 
-| Creating packages requires that docker engine being installed and running
+Creating packages requires that docker engine being installed and running
 on the build machine.  Instructions on how to accomplish this are located at
-https://docs.docker.com
+https://docs.docker.com.
 
 Debian Packages
 ```````````````
 
-| Specify the docker_debs makefile target to build debian packages for the
+Specify the docker_debs makefile target to build debian packages for the
 Ubuntu 14.04 LTS (Trusty) release.
 
-::
+    .. code-block:: shell
 
-    $ make docker_debs
+        $ make docker_debs
 
 Packages are built in the following directory:
 
-| ./build/deb_dist
+    ::
+
+        ./build/deb_dist
+
 
 RPM Packages
 ````````````
 
-|  Specify the docker_el7_rpms makefile target to build RPM packages for the
+Specify the docker_el7_rpms makefile target to build RPM packages for the
 CentOS/RedHat 7 release.
 
-::
+    .. code-block:: shell
 
-    $ make docker_el7_rpms
+        $ make docker_el7_rpms
 
 Packages are built in the following directory:
 
-| ./build/el7
+    ::
 
-|  Specify the docker_el6_rpms makefile target to build RPM packages for the
+        ./build/el7
+
+
+Specify the docker_el6_rpms makefile target to build RPM packages for the
 CentOS/RedHat 6 release.
 
-::
+    .. code-block:: shell
 
-    $ make docker_el6_rpms
+        $ make docker_el6_rpms
 
 Packages are built in the following directory:
 
-| ./build/el6
+    ::
+
+        ./build/el6
+
 
 All Packages
 ````````````
 
-|  Specify the package makefile target to build packages for all supported
-releases
+Specify the package makefile target to build packages for all supported
+releases.
 
-::
+    .. code-block:: shell
 
-    $ make package
+        $ make package
 
 PyPI
 ----
 
 To make a PyPI package...
 
-::
+    .. code-block:: shell
 
-    bash
-    python setup.py sdist
+        python setup.py sdist
 
 Test
 ----
@@ -110,39 +114,36 @@ below.
 Unit Tests
 ``````````
 
-We use pytest for our unit tests
+We use pytest for our unit tests.
 
 #. If you haven't already, install the required test packages and the
    requirements.txt in your virtual environment.
 
-   ::
+   .. code-block:: shell
 
-       shell
        $ pip install hacking pytest pytest-cov
        $ pip install -r requirements.txt
 
-#. | Run the tests and produce a coverage repor. The
-   ``--cov-report=html`` will
-   | create a ``htmlcov/`` directory that you can view in your browser
-   to see the
-   | missing lines of code.
 
-   ::
+#. Run the tests and produce a coverage repor. The ``--cov-report=html`` will
+   create a ``htmlcov/`` directory that you can view in your browser
+   to see the missing lines of code.
 
-       shell
+   .. code-block:: shell
+
        py.test --cov ./icontrol --cov-report=html
        open htmlcov/index.html
 
 Style Checks
 ````````````
 
-| We use the hacking module for our style checks (installed as part of
-| step 1 in the Unit Test section).
+We use the hacking module for our style checks (installed as part of
+step 1 in the Unit Test section).
 
-::
+    .. code-block:: shell
 
-    shell
-    flake8 ./
+        $ flake8 ./
+
 
 Contact
 -------
@@ -165,24 +166,22 @@ License
 Apache V2.0
 ```````````
 
-| Licensed under the Apache License, Version 2.0 (the "License");
-| you may not use this file except in compliance with the License.
-| You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+ou may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-| Unless required by applicable law or agreed to in writing, software
-| distributed under the License is distributed on an "AS IS" BASIS,
-| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
 implied.
-| See the License for the specific language governing permissions and
-| limitations under the License.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 Contributor License Agreement
 `````````````````````````````
 
-| Individuals or business entities who contribute to this project must
-have completed and submitted the `F5 Contributor License
+Individuals or business entities who contribute to this project must have completed and submitted the `F5 Contributor License
 Agreement <http://f5networks.github.io/f5-openstack-docs/cla_landing/index.html>`__
-to Openstack_CLA@f5.com prior to their
-| code submission being included in this project.
+to Openstack_CLA@f5.com prior to their code submission being included in this project.

--- a/agent/setup.py
+++ b/agent/setup.py
@@ -54,7 +54,7 @@ data_files = [('/usr/bin',
               ('/etc/neutron',
                [project_dir + '/agent/etc/neutron/f5-oslbaasv1-agent.ini']),
               ('/usr/share/doc/f5-oslbaasv1-agent',
-               [project_dir + '/docs/f5-oslbaasv1-readme.md',
+               [project_dir + '/docs/f5-oslbaasv1-readme.rst',
                 project_dir + release_readme,
                 project_dir + '/SUPPORT.md'])]
 

--- a/driver/setup.py
+++ b/driver/setup.py
@@ -24,7 +24,7 @@ release = os.environ['RELEASE']
 project_dir = os.environ['PROJECT_DIR']
 
 data_files = [('/usr/share/doc/f5-oslbaasv1-driver',
-               [project_dir + '/docs/f5-oslbaasv1-readme.md',
+               [project_dir + '/docs/f5-oslbaasv1-readme.rst',
                 project_dir + '/SUPPORT.md'])]
 
 if 'bdist_deb' in sys.argv:


### PR DESCRIPTION
@mattgreene -- These commits can be merged across all branches.

Fixes #21 

#### What's this change do?
 I updated the Documentation links to point to http://f5-openstack-lbaasv1.readthedocs.org/en/latest/index.html and made formatting/cleanup edits to README (removed unnecessary indents, fixed code blocks).

#### Where should the reviewer start?
View the README

#### Any background context?