### PR TITLE
Issues: Add ISSUE and PULL_REQUEST templates per new github functiona…

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,33 @@
+* Title: A short but descriptive summary of the issue, whether it be a bug or enhancement.
+* Labels: Click on the gear icon and give us some direction on the type of issue you are filing.
+* Milestone: Leave this field empty.
+* Assignee: If you're not fixing the issue, leave this field empty.
+* Attachments: For bugs, attach the agent log and configuration files
+  * /etc/neutron/f5-oslbaasv1-agent.ini
+  * /var/log/neutron/f5-oslbaasv1-agent.log
+* Details: For bugs, copy and paste the following template into your new issue and fill it out.
+
+#### Agent Version
+<Fill in the version you have installed, such as 1.0.12>
+
+#### Operating System
+<Fill in the host OS of the machine running the agent, such as Ubuntu 14.04>
+
+#### OpenStack Release
+<Fill in the OpenStack release, such as Kilo>
+
+#### Description
+<Describe the bug in detail, steps taken prior to encountering the issue, yand a short explanation of you have deployed openstack and F5 agent>
+
+#### Deployment
+<Explain in reasonable detail your OpenStack deployment, the F5 OpenStack agent, and BIG-IP(s)>
+<Example: Single OpenStack controller with one F5 agent managing a cluster of 4 BIG-IP VEs>
+<Example: Three OpenStack controllers in HA, each with one standalone F5 agent managing a single BIG-IP appliance>
+
+* Details: For enhancements, copy and paste the following template into your new issue and fill it out.
+
+#### OpenStack Release
+<The earliest release in which you would like to see the enhancement>
+
+#### Description
+<Describe the enhancement request in detail>

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+@<reviewer_id>
+#### What issues does this address?
+Fixes #<issueid>
+WIP #<issueid>
+...
+
+#### What's this change do?
+
+#### Where should the reviewer start?
+
+#### Any background context?

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,42 +22,7 @@ help or just want to say hi shoot us an email at <f5_openstack_lbaasv1@f5.com>.
 ## Issues
 Creating issues is good, creating good issues is even better.  By filing meaningful bug reports will lots of information in them helps us figure out what to fix when and how it impacts our users.  We like bugs because it means people are using our code, and we like fixing them even more.
 
-* Title: A short but descriptive summary of the issue, whether it be a bug or enhancement.
-* Labels: Click on the gear icon and give us some direction on the type of issue you are filing.
-* Milestone: Leave this field empty.
-* Assignee: If you're not fixing the issue, leave this field empty.
-* Attachments: For bugs, attach the agent log and configuration files
-  * /etc/neutron/f5-oslbaasv1-agent.ini
-  * /var/log/neutron/f5-oslbaasv1-agent.log
-* Details: For bugs, copy and paste the following template into your new issue and fill it out.
-
-```
-#### Agent Version
-<Fill in the version you have installed, such as 1.0.12>
-
-#### Operating System
-<Fill in the host OS of the machine running the agent, such as Ubuntu 14.04>
-
-#### OpenStack Release
-<Fill in the OpenStack release, such as Kilo>
-
-#### Description
-<Describe the bug in detail, steps taken prior to encountering the issue, yand a short explanation of you have deployed openstack and F5 agent>
-
-#### Deployment
-<Explain in reasonable detail your OpenStack deployment, the F5 OpenStack agent, and BIG-IP(s)>
-<Example: Single OpenStack controller with one F5 agent managing a cluster of 4 BIG-IP VEs>
-<Example: Three OpenStack controllers in HA, each with one standalone F5 agent managing a single BIG-IP appliance>
-```
-* Details: For enhancements, copy and paste the following template into your new issue and fill it out.
-
-```
-#### OpenStack Release
-<The earliest release in which you would like to see the enhancement>
-
-#### Description
-<Describe the enhancement request in detail>
-```
+[Issue-filing template and instructions](.github/ISSUE_TEMPLATE.md)
  
 ## Pull Requests
 If you are submitting a pull request you need to make sure that you have done a few things first.
@@ -69,19 +34,7 @@ _The Hat_ because your request fails unit tests.
 *  Use our [commit template](.git-commit-template.txt)
 *  Use our pull request template
 
-```
-@<reviewer_id>
-#### What issues does this address?
-Fixes #<issueid>
-WIP #<issueid>
-...
-
-#### What's this change do?
-
-#### Where should the reviewer start?
-
-#### Any background context?
-```
+[Pull Request template and instructions](.github/PULL_REQUEST_TEMPLATE.md)
 
 ## Testing
 Creating tests is pretty straight forward and we need you to help us keep ensure the quality of our code.  We write both our unit tests and functional tests using [pytest](http://pytest.org).  We know it is extra work to write these tests but the maintainers and consumers of this code appreciate the effort and writing the tests is pretty easy.


### PR DESCRIPTION
Fixes #55

Problem: Submitter must currently know to look in the CONTRIBUTING doc to grab a template when filing an issue or pull request.

Analysis: Create new templates files supported by new github functionality.

Tests: Create issue and pull request on developer fork.