### PR TITLE
Bug - F5 Agent running prevents HAproxy LBAAS instances from being cr…

### DIFF
--- a/agent/f5/oslbaasv1agent/drivers/bigip/icontrol_driver.py
+++ b/agent/f5/oslbaasv1agent/drivers/bigip/icontrol_driver.py
@@ -260,6 +260,7 @@ class iControlDriver(LBaaSBaseDriver):
         self.device_type = conf.f5_device_type
         self.plugin_rpc = None
         self.__last_connect_attempt = None
+        self.driver_name = 'f5-lbaas-icontrol'
 
         # BIG-IP containers
         self.__bigips = {}
@@ -295,6 +296,8 @@ class iControlDriver(LBaaSBaseDriver):
             LOG.debug(_('Setting static ARP population to %s'
                         % self.conf.f5_populate_static_arp))
             f5const.FDB_POPULATE_STATIC_ARP = self.conf.f5_populate_static_arp
+
+        self.agent_configurations['device_drivers'] = [ self.driver_name ]
 
         self._init_bigip_hostnames()
 


### PR DESCRIPTION
@richbrowne 

#### What issues does this address?
Fixes #74

#### What's this change do?
Problem: The reference service provider scheduler expects to find a 'device_drivers' list in the agent configuration.  The F5 agent does not populate this field, hence the default scheduler throws an error because it expects to always find that key in the dictionary.

Analysis: Modify agent populate this field similar to haproxy (return a list of strings).

Tests: Reproduced failure on Kilo deployment.  Confirmed pool creation on HAProxy after fix is applied.