### PR TITLE
Fixes: bump version # for 8.0.2 release

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -64,9 +64,9 @@ author = u'F5 Networks'
 # built documents.
 #
 # The short X.Y version.
-version = u'2.0'
+version = u'8.0'
 # The full version, including alpha/beta/rc tags.
-release = u'2.0.1'
+release = u'8.0.2'
 
 # OpenStack release
 openstack_release = "Liberty"


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
bumps version release number in docs to 8.0.2 for liberty

#### What's this change do?

#### Where should the reviewer start?

#### Any background context?

Problem:

Analysis:

Unit/Robot tests: