### PR TITLE
Fix broken link in Supported Network Topologies

### DIFF
--- a/docs/includes/topic_vlans-mode.rst
+++ b/docs/includes/topic_vlans-mode.rst
@@ -3,9 +3,9 @@ VLANs
 
 In order to establish connectivity between a BIG-IP® and VLAN, you need to map an interface on the BIG-IP® to an interface on the physical network. In the example below, the BIG-IP interface 1.1 is mapping to the eth0 interface on the hypervisor on which it's running; in turn, eth0 maps to the bridges that provide connectivity from the compute node to the VLAN. The external bridge (br-ex) should have a corresponding ``provider:physical_network`` attribute.
 
-    .. seealso::
+.. seealso::
 
-        F5 OpenStack Configuration Guide: Configure the Neutron Network > :ref:`Configure the Bridge <docs:os-config-ovs-bridge>`.
+    F5 OpenStack Configuration Guide: Configure the Neutron Network -> `Configure the Bridge <http://f5-openstack-docs.readthedocs.io/en/1.0/guides/map_neutron-network-initial-setup.html#configure-the-ovs-bridge>`_.
 
 .. topic:: To create the mapping, edit :file:`/etc/neutron/f5-oslbaasv1-agent.ini`.
 


### PR DESCRIPTION
#### What issues does this address?
Fixes #108

#### What's this change do?
Fixes a broken link from [Supported Network Topologies](http://f5-openstack-lbaasv1.readthedocs.io/en/liberty/map_supported-network-topologies.html#vlans) to the f5-openstack-docs doc set. I'm not sure why intersphinx mapping wasn't working, since the tag was correct; I replaced the ref tag with a link to the appropriate section of the OpenStack configuration guide.

#### Where should the reviewer start?

#### Any background context?

- replaced broken intersphinx link to config-ovs-bridge from topic_vlans with URL