### PR TITLE
added config item f5_http_rps_throttle and a proper HTTP rps iRule

### DIFF
--- a/agent/etc/neutron/f5-oslbaasv1-agent.ini
+++ b/agent/etc/neutron/f5-oslbaasv1-agent.ini
@@ -588,6 +588,21 @@ f5_common_external_networks = True
 # l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
 #                  
 #
+# f5_http_rps_throttle
+#
+# If set to True, VIPs which have a connection limit > 0 and protocol 
+# set to HTTP will have the connection_limit applied as HTTP requests 
+# per second.
+#
+# Is set to False, the default, the connection limit will be applied
+# as an L4 connection limit, the same as it is for TCP based VIPs.
+#
+# This defaults to False because with HTTP 1.1 support, requests are 
+# not nearly as expensive as L4 connections. HTTP RPS limits often 
+# result in partially rendered pages.
+#
+# f5_http_rps_throttle = False
+#
 #
 ###############################################################################
 #  Device Driver Setting

--- a/agent/f5/oslbaasv1agent/drivers/bigip/icontrol_driver.py
+++ b/agent/f5/oslbaasv1agent/drivers/bigip/icontrol_driver.py
@@ -185,6 +185,10 @@ OPTS = [
         'f5_common_external_networks', default=True,
         help=_('Treat external networks as common')
     ),
+    cfg.BoolOpt(
+        'f5_http_rps_throttle', default=False,
+        help=_('Make connections limits enforce HTTP RPS'),
+    ),
     cfg.StrOpt(
         'icontrol_vcmp_hostname',
         help=_('The hostname (name or IP address) to use for vCMP Host '
@@ -297,7 +301,7 @@ class iControlDriver(LBaaSBaseDriver):
                         % self.conf.f5_populate_static_arp))
             f5const.FDB_POPULATE_STATIC_ARP = self.conf.f5_populate_static_arp
 
-        self.agent_configurations['device_drivers'] = [ self.driver_name ]
+        self.agent_configurations['device_drivers'] = [self.driver_name]
 
         self._init_bigip_hostnames()
 


### PR DESCRIPTION
@mattgreene 
#### What issues does this address?
Fixes #127 
WIP #127 
...

#### What's this change do?
Adds a configuration item 'f5_http_rps_throttle' which is a Boolean and defaults to False.
Adds a valid HTTP RPS iRule. The iRule properly keeps the RPS count per virtual server. The previous iRule would never engage the throttle because of a mistake in logic. The new iRule is also CMP compliant.

If the 'f5_http_rps_throttle' config setting is set to True for a VIP with a connection limit > 0, the new iRule will be created for the tenant and associated with the virtual server for the VIP.

If the 'f5_http_rps_throttle' config setting is set to False, the default, on a VIP with a connection limit > 0, the virtaul server will simply have the connection limit set to the VIP connection limit.

#### Where should the reviewer start?

Start an LBaaSv1 agent with 'f5_http_rps_throttle' set to False. Set a VIP connection limit > 0 and confirm the virtual server has the connection limit set.

Start an LBaasv1 agent with 'f5_http_rps_throttle' set to True. Set a VIP connection limit > 0 and confirm that the tenant iRule was created and associated with the appropriate vip.
