### PR TITLE
added config item f5_http_rps_throttle and a proper HTTP rps iRule

### DIFF
--- a/agent/etc/neutron/f5-oslbaasv1-agent.ini
+++ b/agent/etc/neutron/f5-oslbaasv1-agent.ini
@@ -588,6 +588,21 @@ f5_common_external_networks = True
 # l3_binding_static_mappings = 'subnet_a':[('port_a','device_a'),('port_b','device_b')], 'subnet_b':[('port_c','device_a'),('port_d','device_b')]
 #                  
 #
+# f5_http_rps_throttle
+#
+# If set to True, VIPs which have a connection limit > 0 and protocol 
+# set to HTTP will have the connection_limit applied as HTTP requests 
+# per second.
+#
+# Is set to False, the default, the connection limit will be applied
+# as an L4 connection limit, the same as it is for TCP based VIPs.
+#
+# This defaults to False because with HTTP 1.1 support, requests are 
+# not nearly as expensive as L4 connections. HTTP RPS limits often 
+# result in partially rendered pages.
+#
+# f5_http_rps_throttle = False
+#
 #
 ###############################################################################
 #  Device Driver Setting

--- a/agent/f5/oslbaasv1agent/drivers/bigip/icontrol_driver.py
+++ b/agent/f5/oslbaasv1agent/drivers/bigip/icontrol_driver.py
@@ -185,6 +185,10 @@ OPTS = [
         'f5_common_external_networks', default=True,
         help=_('Treat external networks as common')
     ),
+    cfg.BoolOpt(
+        'f5_http_rps_throttle', default=False,
+        help=_('Make connections limits enforce HTTP RPS'),
+    ),
     cfg.StrOpt(
         'icontrol_vcmp_hostname',
         help=_('The hostname (name or IP address) to use for vCMP Host '
@@ -297,7 +301,7 @@ class iControlDriver(LBaaSBaseDriver):
                         % self.conf.f5_populate_static_arp))
             f5const.FDB_POPULATE_STATIC_ARP = self.conf.f5_populate_static_arp
 
-        self.agent_configurations['device_drivers'] = [ self.driver_name ]
+        self.agent_configurations['device_drivers'] = [self.driver_name]
 
         self._init_bigip_hostnames()
 


### PR DESCRIPTION
@<reviewer_id>
#### What issues does this address?
Fixes #127 
WIP #127 
...

#### What's this change do?
Creates a agent config entry to toggle if VIP connection limit should be an L4 connection limit or an L7 HTTP rps limit for HTTP VIPs. By default the VIP will stick to current tested L4 connection limits. 

If the agent config set the f5_http_rps_throttle setting to True, a new iRule is used to implement the HTTP rps throttle.  The new iRule was tested on 11.x and 12.x and is CMP friendly. The old iRule did not work. It never engaged a throttle limit.

#### Where should the reviewer start?
Create an LBaaSv1 Pool and VIP.with no changes to the agent config. On the VIP set the protocol to HTTP and connection_limit attribute > 1. Confirm the BIG-IP virtual server connection limit attribute tracks the VIP connect_limit attribue.

Create and LBaaSv1 Pool and VIP with the f5_http_rps_throttle = True set in the agent config. On the VIP set the protocol to HTTP connection_limit attribute > 1. Confirm that the agent created the HTTP throttle iRule in the client folder and the iRule was associated with the BIG-IP virtual server created for the VIP.

#### Any background context?
The only iRule did not work as intended.