### PR TITLE
Agent repeatedly changes autosync setting on BIG-IP

### DIFF
--- a/common/f5/bigip/interfaces/__init__.py
+++ b/common/f5/bigip/interfaces/__init__.py
@@ -192,6 +192,14 @@ def decorate_name(name=None, folder='Common', use_prefix=True):
     return name
 
 
+def undecorate_name(path, folder='Common'):
+    """ Simple removal of folder as prefix to name """
+    folder = '/' + folder + '/'
+    if path.startswith(folder):
+        path = str(path).replace(folder, '')
+    return path
+
+
 def strip_folder_and_prefix(path):
     """ Strip folder and prefix """
     if isinstance(path, list):

--- a/common/f5/bigip/interfaces/cluster.py
+++ b/common/f5/bigip/interfaces/cluster.py
@@ -16,7 +16,7 @@
 from f5.common import constants as const
 from f5.common.logger import Log
 from f5.bigip import exceptions
-from f5.bigip.interfaces import log
+from f5.bigip.interfaces import log, undecorate_name
 
 import time
 import os
@@ -474,7 +474,7 @@ class Cluster(object):
             response_obj = json.loads(response.text)
             if 'items' in response_obj:
                 for device in response_obj['items']:
-                    return_devices.append(device['name'])
+                    return_devices.append(undecorate_name(device['name']))
             return return_devices
         if response.status_code == 404:
             return []


### PR DESCRIPTION
@jlongstaf  

Issues:
Fixes #132

Problem: Agent stuck in loop connecting to BIG-IP, changing autosync settings, then failing to connect to another BIG-IP in the cluster and raising out.  BIG-IP 11.6.1 changed the behavior of an API to fetch cluster devices.  The old behavior returned the device name in the 'name' field.  The new behavior returns '/Common/' + name in the name field.  The agent code fails to resolve this new name to extract the mgmt address, hence cannot connect.  In the customer environment, the first device in the cluster was 11.6.0 (connects and sets autosync) and the next device was 11.6.1 (fails to connect and cause agent to terminate).

Analysis: Without checking the device version, add a simple method to check and remove '/Common/' from the front of a string and use this new method to normalize the device name when building out an ha cluster.

Tests: Recreated the agent failure and confirmed via log messages that normalizing the device name enables the agent to locate all devices in the cluster and attempt to connect.